### PR TITLE
Readability improvement: Node inspector colours

### DIFF
--- a/components/views/node-inspector/index.js
+++ b/components/views/node-inspector/index.js
@@ -37,7 +37,7 @@ class NodeInspector extends LitElement {
       max-height: 97vh;
       overflow-x: hidden;
       overflow-y: scroll;
-      background: rgba(255,255,255,0.1);
+      background: rgba(0,0,0,0.6);
     }
     .wrap[hidden="true"] {
       display: none;
@@ -45,6 +45,8 @@ class NodeInspector extends LitElement {
     ul {
       width: 100%;
       padding-left: 0;
+      margin-top: 4px;
+      margin-bottom: 8px;
     }
     li {
       width: 100%;


### PR DESCRIPTION
Two tweaks:
1. Set background color of node inspector as transparent black rather than transparent white, helping the white text "pop", improving readability. Previous was white on white which became difficult when the panel was atop of light areas of the map.
2. Sets top and bottom margin for consistent spacing around the panel

Before:
![image](https://github.com/user-attachments/assets/525cf0bd-811a-49ba-9fdb-107e0fc847d9)

After:
![image](https://github.com/user-attachments/assets/b5d857d0-c27a-49a1-90cc-2601f557f150)

